### PR TITLE
Convert sync FS ops to async

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -31,14 +31,14 @@ export const handler = async (argv: ArgumentsCamelCase<CheckArgs>) => {
       overrides.includeExtensions = argv.includeExtensions;
     }
 
-    const config = loadConfig(argv.config, overrides);
+    const config = await loadConfig(argv.config, overrides);
     validateConfig(config);
 
     console.log('Checking markdown files...');
     const result = await checkMarkdownFiles(config);
 
     if (!hasIssues(result.fileIssues)) {
-      const hasConfig = configExists(argv.config);
+      const hasConfig = await configExists(argv.config);
 
       if (!hasConfig) {
         const discovery = await discoverCodeBlocks(

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -22,7 +22,7 @@ export const handler = async (argv: ArgumentsCamelCase<ExtractArgs>) => {
     if (argv.includeExtensions)
       overrides.includeExtensions = argv.includeExtensions;
 
-    const config = loadConfig(argv.config, overrides);
+    const config = await loadConfig(argv.config, overrides);
     validateConfig(config);
 
     console.log('Extracting snippets from code blocks...');

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -23,7 +23,7 @@ export const handler = async (argv: ArgumentsCamelCase<SyncArgs>) => {
     if (argv.includeExtensions)
       overrides.includeExtensions = argv.includeExtensions;
 
-    const config = loadConfig(argv.config, overrides);
+    const config = await loadConfig(argv.config, overrides);
     validateConfig(config);
 
     console.log('Syncing markdown files...');

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
@@ -101,8 +101,8 @@ export function parseSnippetDirective(
   return { filePath: snippetPath };
 }
 
-export function parseMarkdownFile(filePath: string): MarkdownFile {
-  const content = readFileSync(filePath, 'utf-8');
+export async function parseMarkdownFile(filePath: string): Promise<MarkdownFile> {
+  const content = await readFile(filePath, 'utf-8');
   const tree = unified().use(remarkParse).parse(content);
   const codeBlocks: Array<CodeBlock> = [];
 
@@ -137,8 +137,8 @@ export function parseMarkdownFile(filePath: string): MarkdownFile {
   };
 }
 
-export function parseMarkdownForExtraction(filePath: string): MarkdownFile {
-  const content = readFileSync(filePath, 'utf-8');
+export async function parseMarkdownForExtraction(filePath: string): Promise<MarkdownFile> {
+  const content = await readFile(filePath, 'utf-8');
   const tree = unified().use(remarkParse).parse(content);
   const codeBlocks: Array<CodeBlock> = [];
 
@@ -170,10 +170,10 @@ export function parseMarkdownForExtraction(filePath: string): MarkdownFile {
   };
 }
 
-export function loadSnippetContent(
+export async function loadSnippetContent(
   snippetPath: string,
   snippetRoot: string,
-): string {
+): Promise<string> {
   const fullPath = resolve(snippetRoot, snippetPath);
   const resolvedRoot = resolve(snippetRoot);
 
@@ -182,7 +182,7 @@ export function loadSnippetContent(
     throw new Error(`Path traversal attempt detected: ${snippetPath}`);
   }
 
-  return readFileSync(fullPath, 'utf-8');
+  return await readFile(fullPath, 'utf-8');
 }
 
 export function trimBlankLines(content: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,10 @@
+import { access } from 'node:fs/promises';
+
+export async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,10 +1,10 @@
-import fs from 'fs';
+import fs from 'node:fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
 
 export const VERSION = packageJson.version;

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -62,7 +62,7 @@ line 5`;
   });
 
   describe('parseMarkdownFile', () => {
-    it('should parse markdown file with snippet directive', () => {
+    it('should parse markdown file with snippet directive', async () => {
       const markdownContent = `# Test
 
 Here's some code:
@@ -76,7 +76,7 @@ More text here.`;
       const filePath = join(testDir, 'test.md');
       writeFileSync(filePath, markdownContent);
 
-      const result = parseMarkdownFile(filePath);
+      const result = await parseMarkdownFile(filePath);
 
       expect(result.filePath).toBe(filePath);
       expect(result.content).toBe(markdownContent);
@@ -98,7 +98,7 @@ More text here.`;
       `);
     });
 
-    it('should parse snippet directive with line range', () => {
+    it('should parse snippet directive with line range', async () => {
       const markdownContent = `\`\`\`js snippet=utils.js#L5-L10
 old content
 \`\`\``;
@@ -106,7 +106,7 @@ old content
       const filePath = join(testDir, 'test.md');
       writeFileSync(filePath, markdownContent);
 
-      const result = parseMarkdownFile(filePath);
+      const result = await parseMarkdownFile(filePath);
 
       expect(result.codeBlocks[0].snippet).toMatchInlineSnapshot(`
         {
@@ -117,7 +117,7 @@ old content
       `);
     });
 
-    it('should parse snippet directive with single line', () => {
+    it('should parse snippet directive with single line', async () => {
       const markdownContent = `\`\`\`py snippet=main.py#L15
 old content
 \`\`\``;
@@ -125,7 +125,7 @@ old content
       const filePath = join(testDir, 'test.md');
       writeFileSync(filePath, markdownContent);
 
-      const result = parseMarkdownFile(filePath);
+      const result = await parseMarkdownFile(filePath);
 
       expect(result.codeBlocks[0].snippet).toMatchInlineSnapshot(`
         {
@@ -136,7 +136,7 @@ old content
       `);
     });
 
-    it('should parse snippet directive with start line only', () => {
+    it('should parse snippet directive with start line only', async () => {
       const markdownContent = `\`\`\`cpp snippet=main.cpp#L20-
 old content
 \`\`\``;
@@ -144,7 +144,7 @@ old content
       const filePath = join(testDir, 'test.md');
       writeFileSync(filePath, markdownContent);
 
-      const result = parseMarkdownFile(filePath);
+      const result = await parseMarkdownFile(filePath);
 
       expect(result.codeBlocks[0].snippet).toMatchInlineSnapshot(`
         {
@@ -154,7 +154,7 @@ old content
       `);
     });
 
-    it('should ignore code blocks without snippet directive', () => {
+    it('should ignore code blocks without snippet directive', async () => {
       const markdownContent = `\`\`\`ts
 regular code block
 \`\`\`
@@ -166,13 +166,13 @@ snippet block
       const filePath = join(testDir, 'test.md');
       writeFileSync(filePath, markdownContent);
 
-      const result = parseMarkdownFile(filePath);
+      const result = await parseMarkdownFile(filePath);
 
       expect(result.codeBlocks).toHaveLength(1);
       expect(result.codeBlocks[0].snippet?.filePath).toBe('test.js');
     });
 
-    it('should ignore code blocks without language', () => {
+    it('should ignore code blocks without language', async () => {
       const markdownContent = `\`\`\` snippet=test.js
 no language
 \`\`\``;
@@ -180,12 +180,12 @@ no language
       const filePath = join(testDir, 'test.md');
       writeFileSync(filePath, markdownContent);
 
-      const result = parseMarkdownFile(filePath);
+      const result = await parseMarkdownFile(filePath);
 
       expect(result.codeBlocks).toHaveLength(0);
     });
 
-    it('should handle multiple snippet blocks', () => {
+    it('should handle multiple snippet blocks', async () => {
       const markdownContent = `\`\`\`ts snippet=file1.ts
 content 1
 \`\`\`
@@ -201,7 +201,7 @@ content 3
       const filePath = join(testDir, 'test.md');
       writeFileSync(filePath, markdownContent);
 
-      const result = parseMarkdownFile(filePath);
+      const result = await parseMarkdownFile(filePath);
 
       expect(result.codeBlocks).toHaveLength(3);
       expect(result.codeBlocks[0].snippet?.filePath).toBe('file1.ts');
@@ -209,7 +209,7 @@ content 3
       expect(result.codeBlocks[2].snippet?.filePath).toBe('file3.py');
     });
 
-    it('should handle complex file paths', () => {
+    it('should handle complex file paths', async () => {
       const markdownContent = `\`\`\`ts snippet=src/components/Button.tsx#L15-L25
 button content
 \`\`\``;
@@ -217,7 +217,7 @@ button content
       const filePath = join(testDir, 'test.md');
       writeFileSync(filePath, markdownContent);
 
-      const result = parseMarkdownFile(filePath);
+      const result = await parseMarkdownFile(filePath);
 
       expect(result.codeBlocks[0].snippet).toEqual({
         filePath: 'src/components/Button.tsx',
@@ -228,24 +228,24 @@ button content
   });
 
   describe('loadSnippetContent', () => {
-    it('should load content from file', () => {
+    it('should load content from file', async () => {
       const content = 'export const test = "hello";';
       const filePath = join(testDir, 'test.ts');
       writeFileSync(filePath, content);
 
-      const result = loadSnippetContent('test.ts', testDir);
+      const result = await loadSnippetContent('test.ts', testDir);
 
       expect(result).toBe(content);
     });
 
-    it('should handle nested paths', () => {
+    it('should handle nested paths', async () => {
       const content = 'nested file content';
       const nestedDir = join(testDir, 'nested');
       mkdirSync(nestedDir);
       const filePath = join(nestedDir, 'file.js');
       writeFileSync(filePath, content);
 
-      const result = loadSnippetContent('nested/file.js', testDir);
+      const result = await loadSnippetContent('nested/file.js', testDir);
 
       expect(result).toBe(content);
     });


### PR DESCRIPTION
## Summary
- replace synchronous file system APIs with async versions
- adjust CLI commands and parsing utilities to await async calls
- add helper for checking file existence
- update parser tests for async APIs
- refactor to share `fileExists` util across modules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685875b239b4832cb77a48565cab949e