### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+- OS: [e.g. macOS, Windows]
+- Node version: `node -v`
+- md-code version: `md-code --version`
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request
+description: Suggest an idea for this project
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+# Pull Request
+
+Thank you for contributing to md-code!
+
+Please ensure the following before submitting your PR:
+
+- [ ] I have run `npm run lint` and fixed any issues.
+- [ ] I have run `npm run build` to verify the project builds.
+- [ ] I have run `npm test` to ensure all tests pass.
+
+Include a clear description of the changes and reference any related issues.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.


### PR DESCRIPTION
## Summary
- add bug report and feature request templates under `.github/ISSUE_TEMPLATE`
- add pull request checklist referencing lint, build and tests

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858aae37900832c9f93979cc4258c1c