### PR TITLE
Improve snippet numbering

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -318,6 +318,11 @@ export function ensureTrailingNewline(content: string): string {
   return content.endsWith('\n') ? content : content + '\n';
 }
 
+function buildSnippetFileName(index: number, digits: number, extension: string): string {
+  const padded = String(index).padStart(digits, '0');
+  return `snippet-${padded}${extension}`;
+}
+
 export async function extractSnippets(config: Config): Promise<ExtractResult> {
   const result: ExtractResult = {
     extracted: [],
@@ -357,28 +362,27 @@ export async function extractSnippets(config: Config): Promise<ExtractResult> {
         });
         const digits = Math.max(2, String(eligibleBlocks.length).length);
 
-        for (const codeBlock of markdownFile.codeBlocks) {
+        for (const codeBlock of eligibleBlocks) {
           const lang = codeBlock.language;
           const mappedExtension = getExtensionForLanguage(
             lang,
             config.includeExtensions,
+          )!;
+
+          let snippetFileName = buildSnippetFileName(
+            snippetIndex,
+            digits,
+            mappedExtension,
           );
-
-          if (
-            !mappedExtension ||
-            !config.includeExtensions.includes(mappedExtension)
-          ) {
-            continue;
-          }
-
-          const padded = String(snippetIndex).padStart(digits, '0');
-          let snippetFileName = `snippet-${padded}${mappedExtension}`;
           let snippetFilePath = join(outputDir, snippetFileName);
 
           while (await fileExists(snippetFilePath)) {
             snippetIndex++;
-            const newPadded = String(snippetIndex).padStart(digits, '0');
-            snippetFileName = `snippet-${newPadded}${mappedExtension}`;
+            snippetFileName = buildSnippetFileName(
+              snippetIndex,
+              digits,
+              mappedExtension,
+            );
             snippetFilePath = join(outputDir, snippetFileName);
           }
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -348,6 +348,14 @@ export async function extractSnippets(config: Config): Promise<ExtractResult> {
         let hasChanges = false;
         let updatedContent = markdownFile.content;
         let snippetIndex = 1;
+        const eligibleBlocks = markdownFile.codeBlocks.filter((cb) => {
+          const ext = getExtensionForLanguage(
+            cb.language,
+            config.includeExtensions,
+          );
+          return ext && config.includeExtensions.includes(ext);
+        });
+        const digits = Math.max(2, String(eligibleBlocks.length).length);
 
         for (const codeBlock of markdownFile.codeBlocks) {
           const lang = codeBlock.language;
@@ -363,12 +371,14 @@ export async function extractSnippets(config: Config): Promise<ExtractResult> {
             continue;
           }
 
-          let snippetFileName = `snippet${snippetIndex}${mappedExtension}`;
+          const padded = String(snippetIndex).padStart(digits, '0');
+          let snippetFileName = `snippet-${padded}${mappedExtension}`;
           let snippetFilePath = join(outputDir, snippetFileName);
 
           while (await fileExists(snippetFilePath)) {
             snippetIndex++;
-            snippetFileName = `snippet${snippetIndex}${mappedExtension}`;
+            const newPadded = String(snippetIndex).padStart(digits, '0');
+            snippetFileName = `snippet-${newPadded}${mappedExtension}`;
             snippetFilePath = join(outputDir, snippetFileName);
           }
 

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -46,16 +46,16 @@ describe('extractSnippets', () => {
     `);
 
     const snippetDir = join(snippetRoot, 'example');
-    expect(readFileSync(join(snippetDir, 'snippet1.ts'), 'utf-8')).toBe(
+    expect(readFileSync(join(snippetDir, 'snippet-01.ts'), 'utf-8')).toBe(
       "console.log('ts');\n",
     );
-    expect(readFileSync(join(snippetDir, 'snippet2.js'), 'utf-8')).toBe(
+    expect(readFileSync(join(snippetDir, 'snippet-02.js'), 'utf-8')).toBe(
       "console.log('js');\n",
     );
 
     const updated = readFileSync(filePath, 'utf-8');
-    expect(updated).toContain('```ts snippet=example/snippet1.ts');
-    expect(updated).toContain('```js snippet=example/snippet2.js');
+    expect(updated).toContain('```ts snippet=example/snippet-01.ts');
+    expect(updated).toContain('```js snippet=example/snippet-02.js');
   });
 
   it('skips languages not in includeExtensions', async () => {
@@ -80,8 +80,8 @@ describe('extractSnippets', () => {
         "warnings": [],
       }
     `);
-    expect(existsSync(join(snippetRoot, 'skip', 'snippet1.ts'))).toBe(true);
-    expect(existsSync(join(snippetRoot, 'skip', 'snippet2.py'))).toBe(false);
+    expect(existsSync(join(snippetRoot, 'skip', 'snippet-01.ts'))).toBe(true);
+    expect(existsSync(join(snippetRoot, 'skip', 'snippet-02.py'))).toBe(false);
   });
 
   it('ensures all snippet files have trailing newlines', async () => {
@@ -96,19 +96,19 @@ Content with newline:
 \`\`\`js
 console.log('has newline');
 \`\`\``;
-    
+
     const filePath = join(testDir, 'newlines.md');
     await project.write({ 'newlines.md': md });
 
     await extractSnippets(baseConfig);
 
     const snippetDir = join(snippetRoot, 'newlines');
-    const snippet1 = readFileSync(join(snippetDir, 'snippet1.js'), 'utf-8');
-    const snippet2 = readFileSync(join(snippetDir, 'snippet2.js'), 'utf-8');
+    const snippet1 = readFileSync(join(snippetDir, 'snippet-01.js'), 'utf-8');
+    const snippet2 = readFileSync(join(snippetDir, 'snippet-02.js'), 'utf-8');
 
     expect(snippet1).toBe("console.log('no newline')\n");
     expect(snippet2).toBe("console.log('has newline');\n");
-    
+
     expect(snippet1.endsWith('\n')).toBe(true);
     expect(snippet2.endsWith('\n')).toBe(true);
   });


### PR DESCRIPTION
This pull request introduces changes to improve snippet file naming consistency and enhance filtering of code blocks during snippet extraction. The key updates include adding zero-padded numbering to snippet filenames, refining code block filtering logic, and updating associated tests to reflect the new naming convention.

### Enhancements to snippet extraction:

* Updated the snippet filename generation to include zero-padded numbering for consistent naming (e.g., `snippet-01.js` instead of `snippet1.js`). This ensures better sorting and readability. (`src/sync.ts`, [src/sync.tsL366-R381](diffhunk://#diff-1b0cb46cd1fcdaacf73c771bf7eed6e00a12ee030da1dbcca4ae12842e1ecd81L366-R381))
* Introduced filtering for eligible code blocks based on file extensions specified in the configuration, improving precision in snippet extraction. (`src/sync.ts`, [src/sync.tsR351-R358](diffhunk://#diff-1b0cb46cd1fcdaacf73c771bf7eed6e00a12ee030da1dbcca4ae12842e1ecd81R351-R358))

### Test updates:

* Adjusted test cases to validate the new zero-padded snippet naming convention. (`test/extract.test.ts`, [[1]](diffhunk://#diff-7e9f13e0b4304863b2ae560754e95d34ff27126eb329fd12723397c5aef4f9faL49-R58) [[2]](diffhunk://#diff-7e9f13e0b4304863b2ae560754e95d34ff27126eb329fd12723397c5aef4f9faL83-R84) [[3]](diffhunk://#diff-7e9f13e0b4304863b2ae560754e95d34ff27126eb329fd12723397c5aef4f9faL106-R107)

Fixes: #7 
