### PR TITLE
feat: Adds eject command

### DIFF
--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -1,0 +1,6 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+Reference the AGENTS.md file for this project's preferences for LLMs.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Run '...'
 3. See error
@@ -18,6 +19,7 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Environment**
+
 - OS: [e.g. macOS, Windows]
 - Node version: `node -v`
 - md-code version: `md-code --version`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
-
 ## v0.5.2 (2025-06-22)
 
 #### :house: Internal
-* [#3](https://github.com/scalvert/markdown-code/pull/3) Expands test coverage ([@scalvert](https://github.com/scalvert))
-* [#4](https://github.com/scalvert/markdown-code/pull/4) internal: Adds DiscoveryResult type for consistency ([@scalvert](https://github.com/scalvert))
-* [#2](https://github.com/scalvert/markdown-code/pull/2) Fix setup docs ([@scalvert](https://github.com/scalvert))
-* [#1](https://github.com/scalvert/markdown-code/pull/1) Convert sync FS ops to async ([@scalvert](https://github.com/scalvert))
+
+- [#3](https://github.com/scalvert/markdown-code/pull/3) Expands test coverage ([@scalvert](https://github.com/scalvert))
+- [#4](https://github.com/scalvert/markdown-code/pull/4) internal: Adds DiscoveryResult type for consistency ([@scalvert](https://github.com/scalvert))
+- [#2](https://github.com/scalvert/markdown-code/pull/2) Fix setup docs ([@scalvert](https://github.com/scalvert))
+- [#1](https://github.com/scalvert/markdown-code/pull/1) Convert sync FS ops to async ([@scalvert](https://github.com/scalvert))
 
 #### Committers: 1
-- Steve Calvert ([@scalvert](https://github.com/scalvert))
 
+- Steve Calvert ([@scalvert](https://github.com/scalvert))
 
 ## v0.5.1 (2025-06-22)
 

--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -1,0 +1,211 @@
+import { writeFile, rm, unlink } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import type { ArgumentsCamelCase, Argv } from 'yargs';
+import fg from 'fast-glob';
+import { configExists } from '../config.js';
+import { parseMarkdownFile } from '../parser.js';
+import { fileExists } from '../utils.js';
+import {
+  getValidatedConfig,
+  handleError,
+  logWarningsAndErrors,
+  type BaseArgs,
+} from './shared.js';
+
+interface EjectArgs extends BaseArgs {}
+
+export const command = 'eject';
+export const describe = false;
+
+export const builder = (yargs: Argv) => {
+  return yargs.usage(
+    'Remove all snippets, snippet directives, and configuration (destructive)',
+  );
+};
+
+async function confirmEjection(): Promise<boolean> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    console.log(
+      '⚠️  WARNING: This action is destructive and cannot be undone!',
+    );
+    console.log('This will:');
+    console.log('  • Delete all snippet files');
+    console.log('  • Remove snippet directives from markdown files');
+    console.log('  • Delete the configuration file');
+    console.log('');
+
+    const answer = await rl.question(
+      'Are you sure you want to proceed? (y/N): ',
+    );
+    return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+async function removeSnippetDirectives(config: any) {
+  const result = {
+    processed: [] as string[],
+    warnings: [] as string[],
+    errors: [] as string[],
+  };
+
+  try {
+    const markdownFiles = await fg(config.markdownGlob, {
+      ignore: config.excludeGlob,
+    });
+
+    for (const filePath of markdownFiles) {
+      try {
+        const markdownFile = await parseMarkdownFile(filePath);
+        const codeBlocksWithSnippets = markdownFile.codeBlocks.filter(
+          (cb) => cb.snippet,
+        );
+
+        if (codeBlocksWithSnippets.length === 0) {
+          continue;
+        }
+
+        let updatedContent = markdownFile.content;
+        let hasChanges = false;
+
+        for (const codeBlock of codeBlocksWithSnippets) {
+          const originalHeader = `\`\`\`${codeBlock.language} snippet=${
+            codeBlock.snippet!.filePath
+          }`;
+          const newHeader = `\`\`\`${codeBlock.language}`;
+
+          if (updatedContent.includes(originalHeader)) {
+            updatedContent = updatedContent.replace(originalHeader, newHeader);
+            hasChanges = true;
+          }
+        }
+
+        if (hasChanges) {
+          await writeFile(filePath, updatedContent, 'utf-8');
+          result.processed.push(filePath);
+        }
+      } catch (error) {
+        result.errors.push(`Error processing ${filePath}: ${error}`);
+      }
+    }
+  } catch (error) {
+    result.errors.push(`Error finding markdown files: ${error}`);
+  }
+
+  return result;
+}
+
+async function deleteSnippetDirectory(snippetRoot: string) {
+  const result = {
+    deleted: false,
+    warnings: [] as string[],
+    errors: [] as string[],
+  };
+
+  try {
+    const resolvedPath = resolve(snippetRoot);
+
+    if (await fileExists(resolvedPath)) {
+      await rm(resolvedPath, { recursive: true, force: true });
+      result.deleted = true;
+      console.log(`Deleted snippet directory: ${snippetRoot}`);
+    } else {
+      result.warnings.push(`Snippet directory not found: ${snippetRoot}`);
+    }
+  } catch (error) {
+    result.errors.push(`Error deleting snippet directory: ${error}`);
+  }
+
+  return result;
+}
+
+async function deleteConfigFile(configPath?: string) {
+  const result = {
+    deleted: false,
+    warnings: [] as string[],
+    errors: [] as string[],
+  };
+
+  try {
+    const defaultPath = resolve('.markdown-coderc.json');
+    const pathToDelete = configPath ? resolve(configPath) : defaultPath;
+
+    if (await fileExists(pathToDelete)) {
+      await unlink(pathToDelete);
+      result.deleted = true;
+      console.log(`Deleted configuration file: ${pathToDelete}`);
+    } else {
+      result.warnings.push(`Configuration file not found: ${pathToDelete}`);
+    }
+  } catch (error) {
+    result.errors.push(`Error deleting configuration file: ${error}`);
+  }
+
+  return result;
+}
+
+export const handler = async (argv: ArgumentsCamelCase<EjectArgs>) => {
+  try {
+    if (!(await configExists(argv.config))) {
+      console.log('No configuration file found. Nothing to eject.');
+      return;
+    }
+
+    const confirmed = await confirmEjection();
+    if (!confirmed) {
+      console.log('Ejection cancelled.');
+      return;
+    }
+
+    console.log('Starting ejection process...');
+
+    const config = await getValidatedConfig(argv);
+
+    console.log('Removing snippet directives from markdown files...');
+    const directiveResult = await removeSnippetDirectives(config);
+
+    if (directiveResult.processed.length > 0) {
+      console.log(
+        `Removed snippet directives from ${directiveResult.processed.length} files:`,
+      );
+      directiveResult.processed.forEach((file) => console.log(`  ${file}`));
+    } else {
+      console.log('No snippet directives found to remove.');
+    }
+
+    console.log('Deleting snippet directory...');
+    const snippetResult = await deleteSnippetDirectory(config.snippetRoot);
+
+    console.log('Deleting configuration file...');
+    const configResult = await deleteConfigFile(argv.config);
+
+    const allWarnings = [
+      ...directiveResult.warnings,
+      ...snippetResult.warnings,
+      ...configResult.warnings,
+    ];
+
+    const allErrors = [
+      ...directiveResult.errors,
+      ...snippetResult.errors,
+      ...configResult.errors,
+    ];
+
+    logWarningsAndErrors(allWarnings, allErrors);
+
+    if (allErrors.length === 0) {
+      console.log('✅ Ejection completed successfully!');
+    } else {
+      console.log('⚠️  Ejection completed with errors. See above for details.');
+    }
+  } catch (error) {
+    handleError(error);
+  }
+};

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -318,7 +318,11 @@ export function ensureTrailingNewline(content: string): string {
   return content.endsWith('\n') ? content : content + '\n';
 }
 
-function buildSnippetFileName(index: number, digits: number, extension: string): string {
+function buildSnippetFileName(
+  index: number,
+  digits: number,
+  extension: string,
+): string {
   const padded = String(index).padStart(digits, '0');
   return `snippet-${padded}${extension}`;
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1108,4 +1108,16 @@ old content
       expect(updatedMarkdown).not.toContain('const updated = "old content";');
     });
   });
+
+  describe('eject command', () => {
+    it('handles no config file gracefully', async () => {
+      const result = await runBin('eject');
+
+      expect(result.exitCode).toEqual(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toMatchInlineSnapshot(`
+        "No configuration file found. Nothing to eject."
+      `);
+    });
+  });
 });

--- a/test/eject.test.ts
+++ b/test/eject.test.ts
@@ -1,0 +1,479 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { Project } from 'fixturify-project';
+import { extractSnippets } from '../src/sync.js';
+import type { Config } from '../src/types.js';
+
+// Test individual functions without readline interaction
+describe('eject command functionality', () => {
+  let project: Project;
+  let testDir: string;
+  let snippetRoot: string;
+  let baseConfig: Config;
+
+  beforeEach(() => {
+    project = new Project();
+    testDir = project.baseDir;
+    snippetRoot = join(testDir, 'snippets');
+    baseConfig = {
+      snippetRoot,
+      markdownGlob: join(testDir, '**/*.md'),
+      excludeGlob: [],
+      includeExtensions: ['.ts', '.js', '.py'],
+    };
+  });
+
+  afterEach(() => {
+    project.dispose();
+  });
+
+  describe('snippet directive removal', () => {
+    it('should remove snippet directives from markdown files', async () => {
+      const markdownWithDirectives = `# Test Project
+
+## JavaScript Example
+
+\`\`\`javascript snippet=example/snippet-01.js
+function greet(name) {
+  return \`Hello, \${name}!\`;
+}
+\`\`\`
+
+## TypeScript Example
+
+\`\`\`typescript snippet=example/snippet-02.ts
+interface User {
+  name: string;
+  age: number;
+}
+\`\`\`
+
+## Regular Code Block
+
+\`\`\`javascript
+console.log("no snippet directive");
+\`\`\``;
+
+      await project.write({
+        'README.md': markdownWithDirectives,
+      });
+
+      // Manually import the internal function for testing
+      const { parseMarkdownFile } = await import('../src/parser.js');
+      const fg = await import('fast-glob');
+
+      // Test the core removal logic
+      const markdownFiles = await fg.default(baseConfig.markdownGlob);
+      const filePath = markdownFiles[0];
+      const markdownFile = await parseMarkdownFile(filePath);
+      const codeBlocksWithSnippets = markdownFile.codeBlocks.filter(
+        (cb) => cb.snippet,
+      );
+
+      expect(codeBlocksWithSnippets).toHaveLength(2);
+
+      let updatedContent = markdownFile.content;
+      let hasChanges = false;
+
+      for (const codeBlock of codeBlocksWithSnippets) {
+        const originalHeader = `\`\`\`${codeBlock.language} snippet=${
+          codeBlock.snippet!.filePath
+        }`;
+        const newHeader = `\`\`\`${codeBlock.language}`;
+
+        if (updatedContent.includes(originalHeader)) {
+          updatedContent = updatedContent.replace(originalHeader, newHeader);
+          hasChanges = true;
+        }
+      }
+
+      expect(hasChanges).toBe(true);
+      expect(updatedContent).not.toContain('snippet=');
+      expect(updatedContent).toMatchInlineSnapshot(`
+        "# Test Project
+
+        ## JavaScript Example
+
+        \`\`\`javascript
+        function greet(name) {
+          return \`Hello, \${name}!\`;
+        }
+        \`\`\`
+
+        ## TypeScript Example
+
+        \`\`\`typescript
+        interface User {
+          name: string;
+          age: number;
+        }
+        \`\`\`
+
+        ## Regular Code Block
+
+        \`\`\`javascript
+        console.log("no snippet directive");
+        \`\`\`"
+      `);
+    });
+
+    it('should handle markdown files with no snippet directives', async () => {
+      const markdownWithoutDirectives = `# Test
+
+\`\`\`javascript
+console.log("no directives");
+\`\`\``;
+
+      await project.write({
+        'README.md': markdownWithoutDirectives,
+      });
+
+      const { parseMarkdownFile } = await import('../src/parser.js');
+      const fg = await import('fast-glob');
+
+      const markdownFiles = await fg.default(baseConfig.markdownGlob);
+      const filePath = markdownFiles[0];
+      const markdownFile = await parseMarkdownFile(filePath);
+      const codeBlocksWithSnippets = markdownFile.codeBlocks.filter(
+        (cb) => cb.snippet,
+      );
+
+      expect(codeBlocksWithSnippets).toHaveLength(0);
+    });
+
+    it('should handle multiple files with snippet directives', async () => {
+      const readme = `# README
+
+\`\`\`javascript snippet=shared/utils.js
+function helper() {}
+\`\`\``;
+
+      const docs = `# Documentation
+
+\`\`\`typescript snippet=shared/types.ts
+interface Config {}
+\`\`\``;
+
+      await project.write({
+        'README.md': readme,
+        'docs.md': docs,
+      });
+
+      const { parseMarkdownFile } = await import('../src/parser.js');
+      const fg = await import('fast-glob');
+
+      const markdownFiles = await fg.default(baseConfig.markdownGlob);
+      expect(markdownFiles).toHaveLength(2);
+
+      for (const filePath of markdownFiles) {
+        const markdownFile = await parseMarkdownFile(filePath);
+        const codeBlocksWithSnippets = markdownFile.codeBlocks.filter(
+          (cb) => cb.snippet,
+        );
+        expect(codeBlocksWithSnippets).toHaveLength(1);
+      }
+    });
+
+    it('should handle complex snippet directives with line ranges', async () => {
+      const markdownWithRanges = `# Test
+
+\`\`\`javascript snippet=example/snippet-01.js#L1-L5
+console.log("test");
+\`\`\`
+
+\`\`\`typescript snippet=example/snippet-02.ts#L10
+interface Test {}
+\`\`\``;
+
+      await project.write({
+        'README.md': markdownWithRanges,
+      });
+
+      const { parseMarkdownFile } = await import('../src/parser.js');
+      const fg = await import('fast-glob');
+
+      const markdownFiles = await fg.default(baseConfig.markdownGlob);
+      const filePath = markdownFiles[0];
+      const markdownFile = await parseMarkdownFile(filePath);
+      
+      // The parser should handle line ranges correctly
+      const codeBlocksWithSnippets = markdownFile.codeBlocks.filter(
+        (cb) => cb.snippet,
+      );
+      
+      expect(codeBlocksWithSnippets).toHaveLength(2);
+      expect(codeBlocksWithSnippets[0].snippet?.filePath).toBe('example/snippet-01.js');
+      expect(codeBlocksWithSnippets[1].snippet?.filePath).toBe('example/snippet-02.ts');
+    });
+
+    it('should preserve code block content exactly', async () => {
+      const markdownWithSpecialChars = `# Test
+
+\`\`\`javascript snippet=test.js
+function test() {
+  const str = "Hello \\"World\\"";
+  const template = \`Template \${str}\`;
+  return { str, template };
+}
+\`\`\``;
+
+      await project.write({
+        'README.md': markdownWithSpecialChars,
+      });
+
+      const { parseMarkdownFile } = await import('../src/parser.js');
+      const fg = await import('fast-glob');
+
+      const markdownFiles = await fg.default(baseConfig.markdownGlob);
+      const filePath = markdownFiles[0];
+      const markdownFile = await parseMarkdownFile(filePath);
+      const codeBlocksWithSnippets = markdownFile.codeBlocks.filter(
+        (cb) => cb.snippet,
+      );
+
+      expect(codeBlocksWithSnippets).toHaveLength(1);
+
+      let updatedContent = markdownFile.content;
+      for (const codeBlock of codeBlocksWithSnippets) {
+        const originalHeader = `\`\`\`${codeBlock.language} snippet=${
+          codeBlock.snippet!.filePath
+        }`;
+        const newHeader = `\`\`\`${codeBlock.language}`;
+        updatedContent = updatedContent.replace(originalHeader, newHeader);
+      }
+
+      expect(updatedContent).toMatchInlineSnapshot(`
+        "# Test
+
+        \`\`\`javascript
+        function test() {
+          const str = "Hello \\"World\\"";
+          const template = \`Template \${str}\`;
+          return { str, template };
+        }
+        \`\`\`"
+      `);
+      expect(updatedContent).not.toContain('snippet=');
+    });
+  });
+
+  describe('complete workflow simulation', () => {
+    it('should reverse the init --extract workflow', async () => {
+      const originalMarkdown = `# Test Project
+
+## JavaScript Example
+
+\`\`\`javascript
+function greet(name) {
+  return \`Hello, \${name}!\`;
+}
+
+console.log(greet("World"));
+\`\`\`
+
+## TypeScript Example
+
+\`\`\`typescript
+interface User {
+  name: string;
+  age: number;
+}
+
+function createUser(name: string, age: number): User {
+  return { name, age };
+}
+\`\`\``;
+
+      const configContent = JSON.stringify(baseConfig, null, 2);
+
+      await project.write({
+        'README.md': originalMarkdown,
+        '.markdown-coderc.json': configContent,
+      });
+
+      // Step 1: Run extract to create snippets and directives
+      const extractResult = await extractSnippets(baseConfig);
+
+      expect(extractResult).toMatchInlineSnapshot(`
+        {
+          "errors": [],
+          "extracted": [
+            "${testDir}/README.md",
+          ],
+          "snippetsCreated": 2,
+          "warnings": [],
+        }
+      `);
+
+      const markdownAfterExtract = readFileSync(join(testDir, 'README.md'), 'utf-8');
+      expect(markdownAfterExtract).toContain('snippet=readme/snippet-01.js');
+      expect(markdownAfterExtract).toContain('snippet=readme/snippet-02.ts');
+      expect(existsSync(join(snippetRoot, 'readme'))).toBe(true);
+      expect(existsSync(join(testDir, '.markdown-coderc.json'))).toBe(true);
+
+      // Step 2: Simulate the eject process (without readline interaction)
+      const { parseMarkdownFile } = await import('../src/parser.js');
+      const { writeFile, rm, unlink } = await import('node:fs/promises');
+      const { resolve } = await import('node:path');
+      const { fileExists } = await import('../src/utils.js');
+      const fg = await import('fast-glob');
+
+      // Remove snippet directives
+      const markdownFiles = await fg.default(baseConfig.markdownGlob);
+      for (const filePath of markdownFiles) {
+        const markdownFile = await parseMarkdownFile(filePath);
+        const codeBlocksWithSnippets = markdownFile.codeBlocks.filter(
+          (cb) => cb.snippet,
+        );
+
+        if (codeBlocksWithSnippets.length === 0) continue;
+
+        let updatedContent = markdownFile.content;
+        let hasChanges = false;
+
+        for (const codeBlock of codeBlocksWithSnippets) {
+          const originalHeader = `\`\`\`${codeBlock.language} snippet=${
+            codeBlock.snippet!.filePath
+          }`;
+          const newHeader = `\`\`\`${codeBlock.language}`;
+
+          if (updatedContent.includes(originalHeader)) {
+            updatedContent = updatedContent.replace(originalHeader, newHeader);
+            hasChanges = true;
+          }
+        }
+
+        if (hasChanges) {
+          await writeFile(filePath, updatedContent, 'utf-8');
+        }
+      }
+
+      // Delete snippet directory
+      const resolvedSnippetPath = resolve(snippetRoot);
+      if (await fileExists(resolvedSnippetPath)) {
+        await rm(resolvedSnippetPath, { recursive: true, force: true });
+      }
+
+      // Delete config file
+      const configPath = resolve(join(testDir, '.markdown-coderc.json'));
+      if (await fileExists(configPath)) {
+        await unlink(configPath);
+      }
+
+      // Step 3: Verify the eject was successful
+      const markdownAfterEject = readFileSync(join(testDir, 'README.md'), 'utf-8');
+      expect(markdownAfterEject).toMatchInlineSnapshot(`
+        "# Test Project
+
+        ## JavaScript Example
+
+        \`\`\`javascript
+        function greet(name) {
+          return \`Hello, \${name}!\`;
+        }
+
+        console.log(greet("World"));
+        \`\`\`
+
+        ## TypeScript Example
+
+        \`\`\`typescript
+        interface User {
+          name: string;
+          age: number;
+        }
+
+        function createUser(name: string, age: number): User {
+          return { name, age };
+        }
+        \`\`\`"
+      `);
+      expect(markdownAfterEject).not.toContain('snippet=');
+      expect(existsSync(join(snippetRoot))).toBe(false);
+      expect(existsSync(join(testDir, '.markdown-coderc.json'))).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle missing snippet directories gracefully', async () => {
+      const { fileExists } = await import('../src/utils.js');
+      const nonExistentPath = join(testDir, 'does-not-exist');
+      
+      expect(await fileExists(nonExistentPath)).toBe(false);
+    });
+
+    it('should handle missing config files gracefully', async () => {
+      const { configExists } = await import('../src/config.js');
+      const nonExistentConfig = join(testDir, '.does-not-exist.json');
+      
+      expect(await configExists(nonExistentConfig)).toBe(false);
+    });
+
+    it('should handle multiple code blocks in one file', async () => {
+      const markdownWithMultipleBlocks = `# Test
+
+\`\`\`javascript snippet=utils.js
+function helper1() {}
+\`\`\`
+
+Some text in between.
+
+\`\`\`javascript snippet=components.js
+function helper2() {}
+\`\`\`
+
+\`\`\`typescript snippet=types.ts
+interface MyType {}
+\`\`\``;
+
+      await project.write({
+        'README.md': markdownWithMultipleBlocks,
+      });
+
+      const { parseMarkdownFile } = await import('../src/parser.js');
+      const fg = await import('fast-glob');
+
+      const markdownFiles = await fg.default(baseConfig.markdownGlob);
+      const filePath = markdownFiles[0];
+      const markdownFile = await parseMarkdownFile(filePath);
+      const codeBlocksWithSnippets = markdownFile.codeBlocks.filter(
+        (cb) => cb.snippet,
+      );
+
+      expect(codeBlocksWithSnippets).toHaveLength(3);
+      expect(codeBlocksWithSnippets[0].snippet?.filePath).toBe('utils.js');
+      expect(codeBlocksWithSnippets[1].snippet?.filePath).toBe('components.js');
+      expect(codeBlocksWithSnippets[2].snippet?.filePath).toBe('types.ts');
+
+      // Test removal
+      let updatedContent = markdownFile.content;
+      for (const codeBlock of codeBlocksWithSnippets) {
+        const originalHeader = `\`\`\`${codeBlock.language} snippet=${
+          codeBlock.snippet!.filePath
+        }`;
+        const newHeader = `\`\`\`${codeBlock.language}`;
+        updatedContent = updatedContent.replace(originalHeader, newHeader);
+      }
+
+      expect(updatedContent).toMatchInlineSnapshot(`
+        "# Test
+
+        \`\`\`javascript
+        function helper1() {}
+        \`\`\`
+
+        Some text in between.
+
+        \`\`\`javascript
+        function helper2() {}
+        \`\`\`
+
+        \`\`\`typescript
+        interface MyType {}
+        \`\`\`"
+      `);
+      expect(updatedContent).not.toContain('snippet=');
+    });
+  });
+}); 

--- a/test/trailing-newline.test.ts
+++ b/test/trailing-newline.test.ts
@@ -18,10 +18,10 @@ describe('ensureTrailingNewline', () => {
     const content = 'console.log("hello")\r\n';
     const result = ensureTrailingNewline(content);
     expect(result).toBe('console.log("hello")\r\n');
-    
+
     // Verify it ends with newline
     expect(result.endsWith('\n')).toBe(true);
-    
+
     // Verify no double newline was added
     expect(result).not.toBe('console.log("hello")\r\n\n');
   });
@@ -45,4 +45,4 @@ describe('ensureTrailingNewline', () => {
     expect(result).toBe('line1\nline2\r\nline3\r\n');
     expect(result.endsWith('\n')).toBe(true);
   });
-}); 
+});


### PR DESCRIPTION
This pull request introduces several changes, including the addition of a new `eject` command, updates to markdown templates, and minor formatting adjustments. The most significant change is the implementation of the `eject` command, which allows users to remove snippet directives, delete snippet directories, and delete configuration files in a destructive operation.

### New Command Implementation:
* **`src/commands/eject.ts`**: Added the `eject` command, which performs a destructive action to remove snippet directives from markdown files, delete snippet directories, and delete configuration files. Includes user confirmation, error handling, and detailed logging for processed files, warnings, and errors.

### Updates to Templates:
* **`.cursor/rules/agents.mdc`**: Added a reference to the `AGENTS.md` file for project preferences regarding LLMs.
* **`.github/ISSUE_TEMPLATE/bug_report.md`**: Improved formatting by adding blank lines for better readability in the "Steps to reproduce" and "Environment" sections. [[1]](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5R13) [[2]](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5R22)

### Test Enhancements:
* **`test/cli.test.ts`**: Added tests for the `eject` command to ensure it handles scenarios like missing configuration files gracefully.

### Minor Code Adjustments:
* **`src/sync.ts`**: Reformatted the `buildSnippetFileName` function signature for improved readability.

### Documentation:
* **`CHANGELOG.md`**: Fixed formatting inconsistencies in the changelog entries.