### PR TITLE
Add MDX support with non-destructive, offset-addressed extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,38 @@ Perfect for keeping documentation in sync with your actual project source code.
 3. When source files change, `npx markdown-code check` (or `md-code check`) detects drift
 4. Run `npx markdown-code sync` (or `md-code sync`) to update documentation with latest changes
 
+## MDX Support
+
+`.mdx` files (Docusaurus, Nextra, etc.) are fully supported. Point the glob at
+them:
+
+```json
+{
+  "markdownGlob": "docs/**/*.{md,mdx}"
+}
+```
+
+MDX files are parsed with `remark-mdx` + `remark-frontmatter`, so fences nested
+inside JSX components are found, JSX indentation never produces phantom code
+blocks, and `{...}` inside YAML frontmatter parses cleanly. Snippet directives
+coexist with other fence meta (e.g. ```` ```ts title="app.ts" snippet=app.ts ````).
+
+Two guarantees worth knowing:
+
+- **Non-destructive extraction**: `extract` only inserts ` snippet=<ref>` into
+  opening fence lines (offset-addressed, never regex-matched) — stripping the
+  annotations reproduces your original file byte-for-byte.
+- **Fail-safe parsing**: a file that isn't valid MDX (e.g. HTML `<!-- -->`
+  comments, which MDX forbids) is reported and left untouched.
+
+Note: framework-specific MDX extensions (like Docusaurus `{#heading-id}`
+anchors) are not part of the MDX grammar and will be reported as parse errors;
+those files are skipped safely.
+
 ## Features
 
 - **Automatic Sync**: Replace fenced code blocks with contents from real files
+- **MDX Support**: Parse `.mdx` files, including fences nested in JSX
 - **Extract Mode**: Create snippet files from existing code blocks in markdown
 - **Line Range Support**: Extract specific line ranges using `#Lx-Ly` syntax
 - **Check Mode**: Verify documentation is in sync without making changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "mdast": "^3.0.0",
         "picocolors": "^1.1.1",
         "remark": "^15.0.1",
+        "remark-frontmatter": "^5.0.0",
+        "remark-mdx": "^3.1.1",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.4",
         "unist-util-visit": "^5.1.0",
@@ -3816,8 +3818,16 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -3846,6 +3856,15 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -4352,7 +4371,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4365,7 +4383,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -5102,6 +5119,16 @@
         "node": ">=10.13"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5143,6 +5170,36 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6141,6 +6198,30 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -6320,6 +6401,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -6469,6 +6563,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/fs-extra": {
@@ -6913,12 +7015,46 @@
         "node": ">= 12"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -6965,6 +7101,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-in-ssh": {
@@ -7951,6 +8097,113 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -8111,6 +8364,124 @@
         "micromark-util-types": "^2.0.0"
       }
     },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -8152,6 +8523,33 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -8354,6 +8752,31 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -9397,6 +9820,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -10187,6 +10635,36 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -10755,6 +11233,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -11297,6 +11789,19 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
       "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "mdast": "^3.0.0",
     "picocolors": "^1.1.1",
     "remark": "^15.0.1",
+    "remark-frontmatter": "^5.0.0",
+    "remark-mdx": "^3.1.1",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.4",
     "unist-util-visit": "^5.1.0",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,6 +2,8 @@ import { readFile, realpath } from 'node:fs/promises';
 import { resolve, dirname, isAbsolute } from 'node:path';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkMdx from 'remark-mdx';
 import { visit } from 'unist-util-visit';
 import type { Code } from 'mdast';
 import type {
@@ -105,11 +107,26 @@ export function parseSnippetDirective(
   return { filePath: snippetPath, isRemote };
 }
 
+
+/**
+ * Builds the unified processor for a given file. `.mdx` files are parsed with
+ * remark-mdx (JSX, import/export, expressions) plus remark-frontmatter —
+ * frontmatter must be registered so `{...}` inside YAML is never handed to the
+ * MDX expression parser. `.md` files keep the exact historical parser so
+ * existing behavior (and byte offsets) are unchanged.
+ */
+export function createMarkdownProcessor(filePath: string) {
+  if (filePath.toLowerCase().endsWith('.mdx')) {
+    return unified().use(remarkParse).use(remarkFrontmatter).use(remarkMdx);
+  }
+  return unified().use(remarkParse);
+}
+
 export async function parseMarkdownFile(
   filePath: string,
 ): Promise<MarkdownFile> {
   const content = await readFile(filePath, 'utf-8');
-  const tree = unified().use(remarkParse).parse(content);
+  const tree = createMarkdownProcessor(filePath).parse(content);
   const codeBlocks: Array<CodeBlock> = [];
 
   visit(tree, 'code', (node: Code) => {
@@ -147,7 +164,7 @@ export async function parseMarkdownForExtraction(
   filePath: string,
 ): Promise<MarkdownFile> {
   const content = await readFile(filePath, 'utf-8');
-  const tree = unified().use(remarkParse).parse(content);
+  const tree = createMarkdownProcessor(filePath).parse(content);
   const codeBlocks: Array<CodeBlock> = [];
 
   visit(tree, 'code', (node: Code) => {
@@ -317,6 +334,20 @@ export function replaceCodeBlock(
   const openingFence = blockText.slice(0, firstNewlineIndex);
   const closingFence = blockText.slice(lastNewlineIndex + 1);
 
-  const newBlock = `${openingFence}\n${newContent}\n${closingFence}`;
+  // Fences indented inside lists or (in MDX) JSX elements store DEDENTED
+  // content in the mdast node; the parser strips up to the opening fence's
+  // indentation from every line. Re-apply that indentation when splicing so
+  // the fence body stays aligned with its fence markers. Fences at column 1
+  // get an empty prefix, keeping historical output byte-identical.
+  const indent = ' '.repeat(Math.max(0, (codeBlock.columnNumber ?? 1) - 1));
+  const indentedContent =
+    indent === ''
+      ? newContent
+      : newContent
+          .split('\n')
+          .map((line) => (line === '' ? line : indent + line))
+          .join('\n');
+
+  const newBlock = `${openingFence}\n${indentedContent}\n${closingFence}`;
   return markdownContent.slice(0, start) + newBlock + markdownContent.slice(end);
 }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,5 +1,5 @@
 import { writeFile, mkdir, realpath } from 'node:fs/promises';
-import { join, resolve, basename } from 'node:path';
+import { join, resolve, basename, extname } from 'node:path';
 import { createRequire } from 'node:module';
 import fg from 'fast-glob';
 import { fileExists, isInWorkingDir } from './utils.js';
@@ -375,7 +375,7 @@ export async function extractSnippets(
           continue;
         }
 
-        const baseFileName = basename(filePath, '.md');
+        const baseFileName = basename(filePath, extname(filePath));
         const dirName = baseFileName.toLowerCase();
         const outputDir = join(config.snippetRoot, dirName);
 
@@ -392,6 +392,13 @@ export async function extractSnippets(
           return ext && config.includeExtensions.includes(ext);
         });
         const digits = Math.max(2, String(eligibleBlocks.length).length);
+
+        // Pass 1 (document order): write snippet files and record which
+        // annotation belongs to which block.
+        const annotations: Array<{
+          codeBlock: (typeof eligibleBlocks)[number];
+          snippetReference: string;
+        }> = [];
 
         for (const codeBlock of eligibleBlocks) {
           const lang = codeBlock.language;
@@ -421,19 +428,39 @@ export async function extractSnippets(
           await writeFile(snippetFilePath, contentWithNewline, 'utf-8');
           result.snippetsCreated++;
 
-          const snippetReference = `${dirName}/${snippetFileName}`;
-
-          const newCodeBlockStart =
-            '```' + lang + ' snippet=' + snippetReference;
-
-          const escapedLang = lang.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-          updatedContent = updatedContent.replace(
-            new RegExp('^```' + escapedLang + '$', 'm'),
-            newCodeBlockStart,
-          );
+          annotations.push({
+            codeBlock,
+            snippetReference: `${dirName}/${snippetFileName}`,
+          });
 
           hasChanges = true;
           snippetIndex++;
+        }
+
+        // Pass 2 (descending offset order): splice ` snippet=<ref>` into each
+        // block's opening fence line. Pure insertion at a position derived
+        // from the parser's own offsets — the only bytes that change in the
+        // markdown are the annotations themselves, and processing bottom-up
+        // keeps every remaining offset valid. This replaces the previous
+        // first-match regex, which could annotate the wrong same-language
+        // fence and missed fences with meta or indentation.
+        annotations.sort(
+          (a, b) => b.codeBlock.position.start - a.codeBlock.position.start,
+        );
+
+        for (const { codeBlock, snippetReference } of annotations) {
+          const { start, end } = codeBlock.position;
+          const blockText = markdownFile.content.slice(start, end);
+          const firstNewlineIndex = blockText.indexOf('\n');
+          if (firstNewlineIndex === -1) {
+            continue;
+          }
+          const insertPos = start + firstNewlineIndex;
+          updatedContent =
+            updatedContent.slice(0, insertPos) +
+            ' snippet=' +
+            snippetReference +
+            updatedContent.slice(insertPos);
         }
 
         if (hasChanges) {

--- a/test/mdx.test.ts
+++ b/test/mdx.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Project } from 'fixturify-project';
+import { extractSnippets, syncMarkdownFiles, checkMarkdownFiles } from '../src/sync.js';
+import { parseMarkdownFile, parseMarkdownForExtraction } from '../src/parser.js';
+import type { Config } from '../src/types.js';
+
+/**
+ * MDX support tests. The invariants under test:
+ *
+ * 1. Fence detection in .mdx matches the MDX grammar exactly — fences nested
+ *    inside JSX elements are found; JSX-indented prose never produces phantom
+ *    code nodes; `{...}` in YAML frontmatter never reaches the MDX expression
+ *    parser.
+ * 2. Extraction is NON-DESTRUCTIVE BY CONSTRUCTION: the only bytes that may
+ *    change in the markdown are the inserted ` snippet=<ref>` annotations on
+ *    opening fence lines. Stripping those annotations must reproduce the
+ *    original file byte-for-byte.
+ * 3. Extraction is immediately idempotent: a sync right after extract makes
+ *    zero changes, and check passes.
+ * 4. Sync into an indented (JSX-nested) fence re-applies the fence's own
+ *    indentation to the new content.
+ */
+
+const MDX_DOC = `---
+title: Widget guide
+description: Uses {braces} that would break a bare MDX expression parser
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Widgets
+
+Some text with an {/* mdx comment */} expression.
+
+\`\`\`ts title="plain.ts"
+const topLevel = 1;
+\`\`\`
+
+<Tabs>
+  <TabItem value="a" label="A">
+
+    \`\`\`ts
+    const nested = 2;
+    \`\`\`
+
+  </TabItem>
+</Tabs>
+
+<CardGroup cols={2}>
+  <Card title="Indented prose that plain remark would misread as code" />
+</CardGroup>
+`;
+
+function stripAnnotations(content: string): string {
+  return content.replace(/ snippet=[^\s\n]+/g, '');
+}
+
+describe('MDX support', () => {
+  let project: Project;
+  let testDir: string;
+  let baseConfig: Config;
+
+  beforeEach(() => {
+    project = new Project();
+    testDir = project.baseDir;
+    baseConfig = {
+      snippetRoot: join(testDir, 'snippets'),
+      markdownGlob: join(testDir, '**/*.mdx'),
+      excludeGlob: [],
+      includeExtensions: ['.ts', '.js', '.py'],
+      workingDir: testDir,
+    };
+  });
+
+  afterEach(() => {
+    project.dispose();
+  });
+
+  describe('parsing', () => {
+    it('finds fences nested inside JSX and ignores JSX-indented prose', async () => {
+      await project.write({ 'doc.mdx': MDX_DOC });
+      const parsed = await parseMarkdownForExtraction(join(testDir, 'doc.mdx'));
+
+      expect(parsed.codeBlocks).toHaveLength(2);
+      expect(parsed.codeBlocks[0]!.content).toBe('const topLevel = 1;');
+      expect(parsed.codeBlocks[1]!.content).toBe('const nested = 2;');
+    });
+
+    it('parses frontmatter containing braces without an acorn error', async () => {
+      await project.write({ 'doc.mdx': MDX_DOC });
+      await expect(
+        parseMarkdownForExtraction(join(testDir, 'doc.mdx')),
+      ).resolves.toBeDefined();
+    });
+
+    it('keeps .md parsing on the historical plain-remark path', async () => {
+      const md = '# Title\n\n    indented code block\n';
+      await project.write({ 'doc.md': md });
+      const parsed = await parseMarkdownForExtraction(join(testDir, 'doc.md'));
+      // Plain remark still treats 4-space indentation as (lang-less) indented
+      // code, which the lang filter drops — historical behavior preserved.
+      expect(parsed.codeBlocks).toHaveLength(0);
+    });
+  });
+
+  describe('extraction non-destructiveness', () => {
+    it('only adds snippet annotations; stripping them restores the original byte-for-byte', async () => {
+      await project.write({ 'doc.mdx': MDX_DOC });
+      const filePath = join(testDir, 'doc.mdx');
+
+      const result = await extractSnippets(baseConfig);
+      expect(result.errors).toEqual([]);
+      expect(result.snippetsCreated).toBe(2);
+
+      const after = readFileSync(filePath, 'utf-8');
+      expect(after).not.toBe(MDX_DOC);
+      expect(stripAnnotations(after)).toBe(MDX_DOC);
+    });
+
+    it('appends to fence meta instead of replacing it', async () => {
+      await project.write({ 'doc.mdx': MDX_DOC });
+      const filePath = join(testDir, 'doc.mdx');
+
+      await extractSnippets(baseConfig);
+
+      const after = readFileSync(filePath, 'utf-8');
+      expect(after).toContain('```ts title="plain.ts" snippet=doc/');
+    });
+
+    it('annotates the correct fence when multiple same-language fences exist', async () => {
+      await project.write({ 'doc.mdx': MDX_DOC });
+      const filePath = join(testDir, 'doc.mdx');
+
+      await extractSnippets(baseConfig);
+
+      const after = readFileSync(filePath, 'utf-8');
+      // The nested, indented fence must carry its own annotation.
+      expect(after).toMatch(/ {4}```ts snippet=doc\//);
+    });
+
+    it('is idempotent: sync after extract changes nothing and check passes', async () => {
+      await project.write({ 'doc.mdx': MDX_DOC });
+      const filePath = join(testDir, 'doc.mdx');
+
+      await extractSnippets(baseConfig);
+      const afterExtract = readFileSync(filePath, 'utf-8');
+
+      const syncResult = await syncMarkdownFiles(baseConfig);
+      expect(syncResult.errors).toEqual([]);
+      expect(syncResult.updated).toEqual([]);
+      expect(readFileSync(filePath, 'utf-8')).toBe(afterExtract);
+
+      const checkResult = await checkMarkdownFiles(baseConfig);
+      expect(checkResult.inSync).toBe(true);
+    });
+  });
+
+  describe('sync indentation', () => {
+    it('re-applies fence indentation when syncing new content into a JSX-nested fence', async () => {
+      await project.write({ 'doc.mdx': MDX_DOC });
+      const filePath = join(testDir, 'doc.mdx');
+
+      await extractSnippets(baseConfig);
+
+      // Change the nested snippet's source file, then sync.
+      const after = readFileSync(filePath, 'utf-8');
+      const nestedRef = after.match(/ {4}```ts snippet=([^\s\n]+)/)![1]!;
+      const snippetPath = join(baseConfig.snippetRoot, nestedRef);
+      const updated = "const nested = 2;\nconst added = 'line';\n";
+      writeFileSync(snippetPath, updated, 'utf-8');
+
+      const syncResult = await syncMarkdownFiles(baseConfig);
+      expect(syncResult.errors).toEqual([]);
+      expect(syncResult.fileIssues).toEqual([]);
+      expect(syncResult.updated).toHaveLength(1);
+
+      const synced = readFileSync(filePath, 'utf-8');
+      expect(synced).toContain("    const nested = 2;\n    const added = 'line';");
+
+      // And the file must re-parse with the fence still intact.
+      const reparsed = await parseMarkdownFile(filePath);
+      const nested = reparsed.codeBlocks.find((cb) =>
+        cb.content.includes('added'),
+      );
+      expect(nested).toBeDefined();
+      expect(nested!.content).toBe("const nested = 2;\nconst added = 'line';");
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds first-class `.mdx` support (Docusaurus, Nextra, etc.) and hardens extraction so it is **non-destructive by construction**.

### MDX parsing
- `.mdx` files parse with `remark-mdx` + `remark-frontmatter` (frontmatter registered first so `{...}` inside YAML never reaches the MDX expression parser)
- `.md` files keep the exact historical parser — behavior and byte offsets unchanged
- Fences nested inside JSX components are detected; JSX indentation no longer produces phantom code nodes (plain remark both missed real fences inside `<Tabs>`-style components *and* hallucinated indented-code nodes from JSX indentation)
- Invalid MDX (e.g. HTML `<!-- -->` comments) fails safe: reported, file untouched

### Extraction is now insertion-only
The previous annotation used a first-match `^```lang$` regex, which could annotate the **wrong** same-language fence and skipped fences carrying meta (`title="..."`) or indentation. Annotation is now a pure insertion of ` snippet=<ref>` at the parser's own offsets, processed bottom-up:
- the only bytes that change in the markdown are the annotations themselves — stripping them reproduces the original file byte-for-byte
- existing fence meta is preserved (`snippet=` appends)

### Sync is indentation-safe
`replaceCodeBlock` re-applies the opening fence's indentation when splicing content into fences nested in lists or JSX (mdast stores dedented content). Column-1 fences produce byte-identical output to before.

### Also
- extraction dirname now strips the real extension (`.mdx` files no longer produce `foo.mdx/` snippet dirs)

## Verification

- 8 new tests (`test/mdx.test.ts`): JSX-nested fences, frontmatter braces, meta coexistence, annotation-only extraction (strip-and-compare byte identity), sync idempotence, indentation round-trip — **204/204 total pass**
- **Real-world corpus run** against developers.glean.com's 115 authored MDX pages: 312 snippets extracted from 113 files; all 83 modified files byte-identical after annotation stripping (0 violations); `sync` idempotent; `check` clean; the Docusaurus site **builds successfully with all 312 annotations in place** (meta ignored by the renderer). The 2 unparseable files used non-MDX constructs (HTML comment, Docusaurus `{#heading-id}`) and were skipped untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)